### PR TITLE
feat: add color editor with HEX, RGB and HSL formats

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1544,6 +1544,7 @@
       "integrity": "sha512-EhBeSYX0Y6ye8pNebpKrwFJq7BoQ8J5SO6NlvNwwHjSj6adXJViPQrKlsyPw7hLBLvckEMO1yxeGdR82YBBlDg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -1604,6 +1605,7 @@
       "integrity": "sha512-pUXGCuHnnKw6PyYq93lLRiZm3vjuslIy7tus1lIQTYVK9bL8XBgJnCWm8a0KcTtHC84Yya1Q6rtll+duSMj0dg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.39.1",
         "@typescript-eslint/types": "8.39.1",
@@ -1839,6 +1841,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2173,6 +2176,7 @@
       "integrity": "sha512-TS9bTNIryDzStCpJN93aC5VRSW3uTx9sClUn4B87pwiCaJh220otoI0X8mJKr+VcPtniMdN8GKjlwgWGUv5ZKA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2666,6 +2670,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.29.2"
       },
@@ -3491,6 +3496,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.1.tgz",
       "integrity": "sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3798,6 +3804,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3873,6 +3880,7 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3939,6 +3947,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.2.tgz",
       "integrity": "sha512-J0SQBPlQiEXAF7tajiH+rUooJPo0l8KQgyg4/aMunNtrOa7bwuZJsJbDWzeljqQpgftxuq5yNJxQ91O9ts29UQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.6",
@@ -4030,6 +4039,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": 3,
-  "name": "Conta-gotas de cores",
+  "name": "Conta-gotas",
   "short_name": "Conta-gotas",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Capture cores na tela com o conta-gotas do navegador. Salve e copie códigos hex — para designers e desenvolvedores.",
   "icons": {
     "16": "icons/icon-16.png",
@@ -11,7 +11,7 @@
     "128": "icons/icon-128.png"
   },
   "action": {
-    "default_title": "Conta-gotas de cores",
+    "default_title": "Conta-gotas",
     "default_popup": "index.html",
     "default_icon": {
       "16": "icons/icon-16.png",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import {
   BackgroundSelectorContent,
 } from "./components/BackgroundSelector/BackgroundSelector";
 import { ButtonED } from "./components/Button/ButtonED";
+import { ColorCard } from "./components/ColorCard/ColorCard";
 import {
   LanguageSelectorDesktop,
   LanguageSelector,
@@ -99,13 +100,21 @@ function App() {
     localStorage.setItem("backgroundType", isAnimated ? "animated" : "black");
   };
 
+  const handleColorChange = (source: "current" | "previous", newColor: string) => {
+    const updated = { ...colors, [source]: newColor };
+    setColors(updated);
+    if (source === "current") {
+      localStorage.setItem("corSelecionada", newColor);
+    } else {
+      localStorage.setItem("corAnterior", newColor);
+    }
+  };
+
   const handleCopyColor = async (
     color: string | null,
     source: "current" | "previous"
   ) => {
-    if (!color) {
-      return;
-    }
+    if (!color) return;
 
     try {
       await navigator.clipboard.writeText(color);
@@ -227,96 +236,42 @@ function App() {
                 </h2>
               </section>
 
-              {showColors && (
+              {showColors && colors.current && (
                 <section
                   className="mb-4 md:mb-8"
                   aria-label={t("selectedColors")}
                 >
                   <div
                     className={`flex flex-row justify-center ${
-                      isExtensionPopup ? "gap-3 pb-3" : "gap-3 md:gap-6"
+                      isExtensionPopup ? "gap-4 pb-3 px-2" : "gap-6 md:gap-10"
                     }`}
                   >
-                    <article className="flex flex-col items-center">
-                      <h3
-                        className={
-                          isExtensionPopup
-                            ? "text-white text-base"
-                            : "text-white text-lg"
-                        }
-                      >
-                        {t("currentColor")}
-                      </h3>
-                      <div
-                        className={`rounded-lg border-2 border-primary/50 flex items-center justify-center shadow-lg shadow-primary/30 ${
-                          isExtensionPopup
-                            ? "w-[4.5rem] h-[4.5rem]"
-                            : "w-20 h-20 md:w-24 md:h-24"
-                        }`}
-                        style={{
-                          backgroundColor: colors.current || "transparent",
-                        }}
-                        role="img"
-                        aria-label={t("currentColorAria", { color: colors.current })}
-                      >
-                        <span className="text-sm md:text-base font-bold text-white drop-shadow-lg">
-                          {colors.current}
-                        </span>
-                      </div>
-
-                      <button
-                        type="button"
-                        onClick={() => handleCopyColor(colors.current, "current")}
-                        className={`mt-2 rounded-md border border-white/30 text-white hover:bg-white/10 transition-colors ${
-                          isExtensionPopup ? "px-2 py-1 text-xs" : "px-3 py-1 text-sm"
-                        }`}
-                        aria-label={t("copyCurrentColor")}
-                      >
-                        {copiedColor === "current" ? t("copied") : t("copy")}
-                      </button>
-                    </article>
+                    <ColorCard
+                      color={colors.current}
+                      label={t("currentColor")}
+                      colorAriaLabel={t("currentColorAria", { color: colors.current })}
+                      copyAriaLabel={t("copyCurrentColor")}
+                      onColorChange={(c) => handleColorChange("current", c)}
+                      onCopy={() => handleCopyColor(colors.current, "current")}
+                      copied={copiedColor === "current"}
+                      compact={isExtensionPopup}
+                      borderClass="border-primary/50"
+                      shadowClass="shadow-lg shadow-primary/30"
+                    />
 
                     {colors.previous ? (
-                      <article className="flex flex-col items-center">
-                        <h3
-                          className={
-                            isExtensionPopup
-                              ? "text-white text-base"
-                              : "text-white text-lg"
-                          }
-                        >
-                          {t("previousColor")}
-                        </h3>
-                        <div
-                          className={`rounded-lg border-2 border-secondary/50 flex items-center justify-center shadow-lg shadow-secondary/30 ${
-                            isExtensionPopup
-                              ? "w-[4.5rem] h-[4.5rem]"
-                              : "w-20 h-20 md:w-24 md:h-24"
-                          }`}
-                          style={{ backgroundColor: colors.previous }}
-                          role="img"
-                          aria-label={t("previousColorAria", { color: colors.previous })}
-                        >
-                          <span className="text-sm md:text-base font-bold text-white drop-shadow-lg">
-                            {colors.previous}
-                          </span>
-                        </div>
-
-                        <button
-                          type="button"
-                          onClick={() =>
-                            handleCopyColor(colors.previous, "previous")
-                          }
-                          className={`mt-2 rounded-md border border-white/30 text-white hover:bg-white/10 transition-colors ${
-                            isExtensionPopup
-                              ? "px-2 py-1 text-xs"
-                              : "px-3 py-1 text-sm"
-                          }`}
-                          aria-label={t("copyPreviousColor")}
-                        >
-                          {copiedColor === "previous" ? t("copied") : t("copy")}
-                        </button>
-                      </article>
+                      <ColorCard
+                        color={colors.previous}
+                        label={t("previousColor")}
+                        colorAriaLabel={t("previousColorAria", { color: colors.previous })}
+                        copyAriaLabel={t("copyPreviousColor")}
+                        onColorChange={(c) => handleColorChange("previous", c)}
+                        onCopy={() => handleCopyColor(colors.previous, "previous")}
+                        copied={copiedColor === "previous"}
+                        compact={isExtensionPopup}
+                        borderClass="border-secondary/50"
+                        shadowClass="shadow-lg shadow-secondary/30"
+                      />
                     ) : null}
                   </div>
                 </section>

--- a/src/components/ColorCard/ColorCard.tsx
+++ b/src/components/ColorCard/ColorCard.tsx
@@ -1,0 +1,191 @@
+import { type FC, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  hexToRgb,
+  hslToRgb,
+  isValidHex,
+  rgbToHex,
+  rgbToHsl,
+} from "../../utils/colorUtils";
+
+type ColorFormat = "hex" | "rgb" | "hsl";
+
+interface IProps {
+  color: string;
+  label: string;
+  colorAriaLabel: string;
+  copyAriaLabel: string;
+  onColorChange: (color: string) => void;
+  onCopy: () => void;
+  copied: boolean;
+  compact?: boolean;
+  borderClass: string;
+  shadowClass: string;
+}
+
+export const ColorCard: FC<IProps> = ({
+  color,
+  label,
+  colorAriaLabel,
+  copyAriaLabel,
+  onColorChange,
+  onCopy,
+  copied,
+  compact = false,
+  borderClass,
+  shadowClass,
+}) => {
+  const { t } = useTranslation();
+  const [format, setFormat] = useState<ColorFormat>("hex");
+  const colorInputRef = useRef<HTMLInputElement>(null);
+
+  const rgb = hexToRgb(color) ?? { r: 0, g: 0, b: 0 };
+  const hsl = rgbToHsl(rgb.r, rgb.g, rgb.b);
+
+  const handleHexChange = (raw: string) => {
+    const hex = raw.startsWith("#") ? raw : "#" + raw;
+    if (isValidHex(hex)) onColorChange(hex.toLowerCase());
+  };
+
+  const handleRgbChange = (channel: "r" | "g" | "b", value: string) => {
+    const num = Math.max(0, Math.min(255, parseInt(value) || 0));
+    onColorChange(rgbToHex({ ...rgb, [channel]: num }.r, { ...rgb, [channel]: num }.g, { ...rgb, [channel]: num }.b));
+  };
+
+  const handleHslChange = (channel: "h" | "s" | "l", value: string) => {
+    const max = channel === "h" ? 360 : 100;
+    const num = Math.max(0, Math.min(max, parseInt(value) || 0));
+    const newRgb = hslToRgb(
+      channel === "h" ? num : hsl.h,
+      channel === "s" ? num : hsl.s,
+      channel === "l" ? num : hsl.l,
+    );
+    onColorChange(rgbToHex(newRgb.r, newRgb.g, newRgb.b));
+  };
+
+  const inputBase =
+    "bg-white/10 border border-white/20 rounded text-white font-mono text-center focus:outline-none focus:border-white/50 transition-colors";
+
+  return (
+    <article className="flex flex-col items-center gap-2">
+      <h3 className={compact ? "text-white text-base" : "text-white text-lg"}>
+        {label}
+      </h3>
+
+      {/* Swatch — clica para abrir o color picker nativo */}
+      <div className="relative cursor-pointer" onClick={() => colorInputRef.current?.click()}>
+        <div
+          className={`rounded-lg border-2 ${borderClass} ${shadowClass} flex items-center justify-center ${
+            compact ? "w-[4.5rem] h-[4.5rem]" : "w-20 h-20 md:w-24 md:h-24"
+          }`}
+          style={{ backgroundColor: color }}
+          role="img"
+          aria-label={colorAriaLabel}
+          title={t("editColor")}
+        >
+          <span className={`font-bold text-white drop-shadow-lg select-none ${compact ? "text-[10px]" : "text-sm md:text-base"}`}>
+            {color}
+          </span>
+        </div>
+        {/* Ícone de lápis no canto */}
+        <div className="absolute -bottom-1 -right-1 bg-white/20 backdrop-blur-sm rounded-full p-1 pointer-events-none">
+          <svg xmlns="http://www.w3.org/2000/svg" className="w-3 h-3 text-white" viewBox="0 0 20 20" fill="currentColor">
+            <path d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z" />
+          </svg>
+        </div>
+        <input
+          ref={colorInputRef}
+          type="color"
+          value={color}
+          onChange={(e) => onColorChange(e.target.value)}
+          className="absolute inset-0 opacity-0 w-full h-full cursor-pointer"
+          aria-label={t("editColor")}
+        />
+      </div>
+
+      {/* Seletor de formato */}
+      <div className="flex border border-white/20 rounded overflow-hidden text-[11px]">
+        {(["hex", "rgb", "hsl"] as ColorFormat[]).map((f) => (
+          <button
+            key={f}
+            type="button"
+            onClick={() => setFormat(f)}
+            className={`px-2 py-0.5 uppercase font-medium transition-colors ${
+              format === f
+                ? "bg-white/30 text-white"
+                : "text-white/50 hover:text-white hover:bg-white/10"
+            }`}
+          >
+            {f}
+          </button>
+        ))}
+      </div>
+
+      {/* Inputs por formato */}
+      {format === "hex" && (
+        <input
+          key={`hex-${color}`}
+          type="text"
+          defaultValue={color}
+          onBlur={(e) => handleHexChange(e.target.value)}
+          onKeyDown={(e) =>
+            e.key === "Enter" && handleHexChange((e.target as HTMLInputElement).value)
+          }
+          className={`${inputBase} w-[5.5rem] px-1.5 py-1 text-xs`}
+          maxLength={7}
+          spellCheck={false}
+        />
+      )}
+
+      {format === "rgb" && (
+        <div className="flex gap-1">
+          {(["r", "g", "b"] as const).map((ch) => (
+            <div key={ch} className="flex flex-col items-center gap-0.5">
+              <input
+                type="number"
+                min={0}
+                max={255}
+                value={rgb[ch]}
+                onChange={(e) => handleRgbChange(ch, e.target.value)}
+                className={`${inputBase} w-10 px-0.5 py-1 text-[11px]`}
+              />
+              <span className="text-white/50 text-[10px] uppercase">{ch}</span>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {format === "hsl" && (
+        <div className="flex gap-1">
+          {(["h", "s", "l"] as const).map((ch) => (
+            <div key={ch} className="flex flex-col items-center gap-0.5">
+              <input
+                type="number"
+                min={0}
+                max={ch === "h" ? 360 : 100}
+                value={hsl[ch]}
+                onChange={(e) => handleHslChange(ch, e.target.value)}
+                className={`${inputBase} w-10 px-0.5 py-1 text-[11px]`}
+              />
+              <span className="text-white/50 text-[10px]">
+                {ch.toUpperCase()}{ch === "h" ? "°" : "%"}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Botão copiar */}
+      <button
+        type="button"
+        onClick={onCopy}
+        className={`rounded-md border border-white/30 text-white hover:bg-white/10 transition-colors ${
+          compact ? "px-2 py-1 text-xs" : "px-3 py-1 text-sm"
+        }`}
+        aria-label={copyAriaLabel}
+      >
+        {copied ? t("copied") : t("copy")}
+      </button>
+    </article>
+  );
+};

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -31,5 +31,6 @@
   "openMenu": "Open menu",
   "settings": "Settings",
   "closeMenu": "Close menu",
-  "language": "Language:"
+  "language": "Language:",
+  "editColor": "Edit color"
 }

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -31,5 +31,6 @@
   "openMenu": "メニューを開く",
   "settings": "設定",
   "closeMenu": "メニューを閉じる",
-  "language": "言語:"
+  "language": "言語:",
+  "editColor": "色を編集"
 }

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -31,5 +31,6 @@
   "openMenu": "Abrir menu",
   "settings": "Configurações",
   "closeMenu": "Fechar menu",
-  "language": "Idioma:"
+  "language": "Idioma:",
+  "editColor": "Editar cor"
 }

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -31,5 +31,6 @@
   "openMenu": "Открыть меню",
   "settings": "Настройки",
   "closeMenu": "Закрыть меню",
-  "language": "Язык:"
+  "language": "Язык:",
+  "editColor": "Редактировать цвет"
 }

--- a/src/utils/colorUtils.ts
+++ b/src/utils/colorUtils.ts
@@ -1,0 +1,82 @@
+export interface RGB { r: number; g: number; b: number }
+export interface HSL { h: number; s: number; l: number }
+
+export function hexToRgb(hex: string): RGB | null {
+  const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+  return result
+    ? {
+        r: parseInt(result[1], 16),
+        g: parseInt(result[2], 16),
+        b: parseInt(result[3], 16),
+      }
+    : null;
+}
+
+export function rgbToHex(r: number, g: number, b: number): string {
+  return (
+    "#" +
+    [r, g, b]
+      .map((x) => Math.max(0, Math.min(255, x)).toString(16).padStart(2, "0"))
+      .join("")
+  );
+}
+
+export function rgbToHsl(r: number, g: number, b: number): HSL {
+  const rn = r / 255;
+  const gn = g / 255;
+  const bn = b / 255;
+  const max = Math.max(rn, gn, bn);
+  const min = Math.min(rn, gn, bn);
+  let h = 0;
+  let s = 0;
+  const l = (max + min) / 2;
+
+  if (max !== min) {
+    const d = max - min;
+    s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+    switch (max) {
+      case rn: h = ((gn - bn) / d + (gn < bn ? 6 : 0)) / 6; break;
+      case gn: h = ((bn - rn) / d + 2) / 6; break;
+      case bn: h = ((rn - gn) / d + 4) / 6; break;
+    }
+  }
+
+  return {
+    h: Math.round(h * 360),
+    s: Math.round(s * 100),
+    l: Math.round(l * 100),
+  };
+}
+
+export function hslToRgb(h: number, s: number, l: number): RGB {
+  const hn = h / 360;
+  const sn = s / 100;
+  const ln = l / 100;
+
+  if (sn === 0) {
+    const v = Math.round(ln * 255);
+    return { r: v, g: v, b: v };
+  }
+
+  const hue2rgb = (p: number, q: number, t: number) => {
+    if (t < 0) t += 1;
+    if (t > 1) t -= 1;
+    if (t < 1 / 6) return p + (q - p) * 6 * t;
+    if (t < 1 / 2) return q;
+    if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6;
+    return p;
+  };
+
+  const q = ln < 0.5 ? ln * (1 + sn) : ln + sn - ln * sn;
+  const p = 2 * ln - q;
+
+  return {
+    r: Math.round(hue2rgb(p, q, hn + 1 / 3) * 255),
+    g: Math.round(hue2rgb(p, q, hn) * 255),
+    b: Math.round(hue2rgb(p, q, hn - 1 / 3) * 255),
+  };
+}
+
+export function isValidHex(hex: string): boolean {
+  return /^#[0-9a-fA-F]{6}$/.test(hex);
+}


### PR DESCRIPTION
## Resumo

> ⚠️ Este PR depende de gleonbs/eyeDropper#2 — faça merge do PR de idiomas antes.

- Adiciona editor de cores interativo para as duas cores selecionadas (atual e anterior)
- O usuário pode visualizar e editar a cor em **HEX**, **RGB** e **HSL**
- Alterações manuais são salvas automaticamente no `localStorage`

## Novos arquivos

- `src/utils/colorUtils.ts` — funções de conversão entre formatos de cor (hex ↔ rgb ↔ hsl)
- `src/components/ColorCard/ColorCard.tsx` — componente de exibição e edição de cor

## Comportamento do `ColorCard`

- **Swatch clicável** — abre o color picker nativo do browser (com ícone de lápis no canto)
- **Tabs de formato** — alterna entre HEX, RGB e HSL
- **Inputs editáveis:**
  - **HEX**: campo de texto, confirma com Enter ou ao perder o foco
  - **RGB**: 3 campos numéricos (0–255) com atualização em tempo real
  - **HSL**: H em graus (0–360°), S e L em porcentagem (0–100%)
- **Botão copiar** mantido abaixo dos inputs
- Funciona nas duas cores e nos dois modos (web + extensão Chrome)

## Plano de testes

- [ ] Selecionar uma cor com o eyedropper e verificar que o `ColorCard` aparece
- [ ] Clicar no swatch e alterar a cor pelo color picker nativo
- [ ] Editar o valor HEX diretamente no input
- [ ] Editar os valores RGB e verificar que o swatch atualiza em tempo real
- [ ] Editar os valores HSL e verificar que o swatch atualiza em tempo real
- [ ] Recarregar a página e confirmar que a cor editada foi salva
- [ ] Testar na extensão Chrome (modo compacto)