### PR TITLE
feat: color history, flexible copy formats and palette export

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   BackgroundSelector,
@@ -6,11 +6,15 @@ import {
 } from "./components/BackgroundSelector/BackgroundSelector";
 import { ButtonED } from "./components/Button/ButtonED";
 import { ColorCard } from "./components/ColorCard/ColorCard";
+import { ColorHistory } from "./components/ColorHistory/ColorHistory";
+import { ExportPalette } from "./components/ExportPalette/ExportPalette";
 import {
   LanguageSelectorDesktop,
   LanguageSelector,
 } from "./components/LanguageSelector/LanguageSelector";
 import { MobileMenu } from "./components/MobileMenu/MobileMenu";
+
+const MAX_HISTORY = 10;
 
 interface ColorData {
   current: string | null;
@@ -21,16 +25,12 @@ function App() {
   const { t } = useTranslation();
   const isExtensionPopup = window.location.protocol === "chrome-extension:";
 
-  const [colors, setColors] = useState<ColorData>({
-    current: null,
-    previous: null,
-  });
+  const [colors, setColors] = useState<ColorData>({ current: null, previous: null });
+  const [history, setHistory] = useState<string[]>([]);
   const [error, setError] = useState<string>("");
   const [title, setTitle] = useState<string>("noColorSelected");
   const [showColors, setShowColors] = useState<boolean>(false);
-  const [isAnimatedBackground, setIsAnimatedBackground] =
-    useState<boolean>(false);
-  const [copiedColor, setCopiedColor] = useState<"current" | "previous" | null>(null);
+  const [isAnimatedBackground, setIsAnimatedBackground] = useState<boolean>(false);
 
   useEffect(() => {
     if (!("EyeDropper" in window)) {
@@ -42,40 +42,41 @@ function App() {
     const savedCurrent = localStorage.getItem("corSelecionada");
     const savedPrevious = localStorage.getItem("corAnterior");
     const savedBackground = localStorage.getItem("backgroundType");
+    const savedHistory = localStorage.getItem("colorHistory");
 
     if (savedCurrent) {
-      setColors({
-        current: savedCurrent,
-        previous: savedPrevious,
-      });
+      setColors({ current: savedCurrent, previous: savedPrevious });
       setTitle("colorsTitle");
       setShowColors(true);
     }
-
     if (savedBackground) {
       setIsAnimatedBackground(savedBackground === "animated");
     }
+    if (savedHistory) {
+      try { setHistory(JSON.parse(savedHistory)); } catch { /* ignore */ }
+    }
+  }, []);
+
+  const addToHistory = useCallback((color: string) => {
+    setHistory((prev) => {
+      const next = [color, ...prev.filter((c) => c !== color)].slice(0, MAX_HISTORY);
+      localStorage.setItem("colorHistory", JSON.stringify(next));
+      return next;
+    });
   }, []);
 
   const handleChooseColor = async () => {
     try {
       const dropper = new EyeDropper();
       const result = await dropper.open();
-
-      const newColors = {
-        current: result.sRGBHex,
-        previous: colors.current,
-      };
-
+      const newColors = { current: result.sRGBHex, previous: colors.current };
       setColors(newColors);
       setTitle("colorsTitle");
       setShowColors(true);
       setError("");
-
       localStorage.setItem("corSelecionada", result.sRGBHex);
-      if (colors.current) {
-        localStorage.setItem("corAnterior", colors.current);
-      }
+      if (colors.current) localStorage.setItem("corAnterior", colors.current);
+      addToHistory(result.sRGBHex);
     } catch {
       setError("colorSelectionError");
     }
@@ -86,11 +87,9 @@ function App() {
       setTitle("noColorsToDelete");
       return;
     }
-
     setTitle("colorsCleared");
     setColors({ current: null, previous: null });
     setShowColors(false);
-
     localStorage.removeItem("corSelecionada");
     localStorage.removeItem("corAnterior");
   };
@@ -101,32 +100,25 @@ function App() {
   };
 
   const handleColorChange = (source: "current" | "previous", newColor: string) => {
-    const updated = { ...colors, [source]: newColor };
-    setColors(updated);
-    if (source === "current") {
-      localStorage.setItem("corSelecionada", newColor);
-    } else {
-      localStorage.setItem("corAnterior", newColor);
-    }
+    setColors((prev) => ({ ...prev, [source]: newColor }));
+    localStorage.setItem(
+      source === "current" ? "corSelecionada" : "corAnterior",
+      newColor,
+    );
   };
 
-  const handleCopyColor = async (
-    color: string | null,
-    source: "current" | "previous"
-  ) => {
-    if (!color) return;
+  const handleUseFromHistory = (color: string) => {
+    const prev = colors.current;
+    setColors({ current: color, previous: prev });
+    setTitle("colorsTitle");
+    setShowColors(true);
+    localStorage.setItem("corSelecionada", color);
+    if (prev) localStorage.setItem("corAnterior", prev);
+  };
 
-    try {
-      await navigator.clipboard.writeText(color);
-      setCopiedColor(source);
-      window.setTimeout(() => {
-        setCopiedColor((activeSource) =>
-          activeSource === source ? null : activeSource
-        );
-      }, 1500);
-    } catch {
-      setError("copyError");
-    }
+  const handleClearHistory = () => {
+    setHistory([]);
+    localStorage.removeItem("colorHistory");
   };
 
   return (
@@ -178,9 +170,7 @@ function App() {
           <header className="text-center">
             <h1
               className={`font-bold ${
-                isExtensionPopup
-                  ? "text-2xl"
-                  : "text-3xl md:text-4xl lg:text-5xl"
+                isExtensionPopup ? "text-2xl" : "text-3xl md:text-4xl lg:text-5xl"
               } ${
                 isAnimatedBackground
                   ? "text-white"
@@ -201,9 +191,7 @@ function App() {
               ariaLabel={t("openColorPicker")}
               variant={isAnimatedBackground ? "white" : "primary"}
               className={
-                isExtensionPopup
-                  ? "w-full py-2 px-4 text-base md:text-base"
-                  : undefined
+                isExtensionPopup ? "w-full py-2 px-4 text-base md:text-base" : undefined
               }
             >
               {t("chooseColor")}
@@ -215,7 +203,7 @@ function App() {
               <div
                 className={`text-error text-center rounded-xl border border-error/30 ${
                   isExtensionPopup ? "text-base p-3" : "text-lg md:text-xl p-4"
-                } ${isAnimatedBackground ? "bg-black/70" : "bg-error/10 "}`}
+                } ${isAnimatedBackground ? "bg-black/70" : "bg-error/10"}`}
                 role="alert"
                 aria-live="polite"
               >
@@ -238,22 +226,20 @@ function App() {
 
               {showColors && colors.current && (
                 <section
-                  className="mb-4 md:mb-8"
+                  className={`${isExtensionPopup ? "pb-3" : "mb-4 md:mb-6"}`}
                   aria-label={t("selectedColors")}
                 >
                   <div
                     className={`flex flex-row justify-center ${
-                      isExtensionPopup ? "gap-4 pb-3 px-2" : "gap-6 md:gap-10"
+                      isExtensionPopup ? "gap-4 px-2" : "gap-6 md:gap-10"
                     }`}
                   >
                     <ColorCard
                       color={colors.current}
                       label={t("currentColor")}
                       colorAriaLabel={t("currentColorAria", { color: colors.current })}
-                      copyAriaLabel={t("copyCurrentColor")}
                       onColorChange={(c) => handleColorChange("current", c)}
-                      onCopy={() => handleCopyColor(colors.current, "current")}
-                      copied={copiedColor === "current"}
+                      onError={setError}
                       compact={isExtensionPopup}
                       borderClass="border-primary/50"
                       shadowClass="shadow-lg shadow-primary/30"
@@ -264,16 +250,21 @@ function App() {
                         color={colors.previous}
                         label={t("previousColor")}
                         colorAriaLabel={t("previousColorAria", { color: colors.previous })}
-                        copyAriaLabel={t("copyPreviousColor")}
                         onColorChange={(c) => handleColorChange("previous", c)}
-                        onCopy={() => handleCopyColor(colors.previous, "previous")}
-                        copied={copiedColor === "previous"}
+                        onError={setError}
                         compact={isExtensionPopup}
                         borderClass="border-secondary/50"
                         shadowClass="shadow-lg shadow-secondary/30"
                       />
                     ) : null}
                   </div>
+
+                  <ColorHistory
+                    history={history}
+                    onUseColor={handleUseFromHistory}
+                    onClear={handleClearHistory}
+                    compact={isExtensionPopup}
+                  />
                 </section>
               )}
             </div>
@@ -281,7 +272,7 @@ function App() {
 
           <footer
             className={`text-center border-t border-white/10 ${
-              isExtensionPopup ? "pt-3" : "pt-3 md:pt-6"
+              isExtensionPopup ? "pt-3 space-y-2" : "pt-3 md:pt-4 space-y-3"
             }`}
           >
             <ButtonED
@@ -289,13 +280,13 @@ function App() {
               ariaLabel={t("clearAllColors")}
               variant={isAnimatedBackground ? "white" : "primary"}
               className={
-                isExtensionPopup
-                  ? "w-full py-2 px-4 text-base md:text-base"
-                  : ""
+                isExtensionPopup ? "w-full py-2 px-4 text-base md:text-base" : ""
               }
             >
               {t("clearColors")}
             </ButtonED>
+
+            <ExportPalette colors={history} />
           </footer>
 
           {isExtensionPopup ? (

--- a/src/components/ColorCard/ColorCard.tsx
+++ b/src/components/ColorCard/ColorCard.tsx
@@ -1,6 +1,8 @@
 import { type FC, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
+  type ColorFormat,
+  formatColor,
   hexToRgb,
   hslToRgb,
   isValidHex,
@@ -8,16 +10,12 @@ import {
   rgbToHsl,
 } from "../../utils/colorUtils";
 
-type ColorFormat = "hex" | "rgb" | "hsl";
-
 interface IProps {
   color: string;
   label: string;
   colorAriaLabel: string;
-  copyAriaLabel: string;
   onColorChange: (color: string) => void;
-  onCopy: () => void;
-  copied: boolean;
+  onError?: (key: string) => void;
   compact?: boolean;
   borderClass: string;
   shadowClass: string;
@@ -27,16 +25,16 @@ export const ColorCard: FC<IProps> = ({
   color,
   label,
   colorAriaLabel,
-  copyAriaLabel,
   onColorChange,
-  onCopy,
-  copied,
+  onError,
   compact = false,
   borderClass,
   shadowClass,
 }) => {
   const { t } = useTranslation();
   const [format, setFormat] = useState<ColorFormat>("hex");
+  const [alpha, setAlpha] = useState(1);
+  const [copied, setCopied] = useState(false);
   const colorInputRef = useRef<HTMLInputElement>(null);
 
   const rgb = hexToRgb(color) ?? { r: 0, g: 0, b: 0 };
@@ -49,18 +47,26 @@ export const ColorCard: FC<IProps> = ({
 
   const handleRgbChange = (channel: "r" | "g" | "b", value: string) => {
     const num = Math.max(0, Math.min(255, parseInt(value) || 0));
-    onColorChange(rgbToHex({ ...rgb, [channel]: num }.r, { ...rgb, [channel]: num }.g, { ...rgb, [channel]: num }.b));
+    const next = { ...rgb, [channel]: num };
+    onColorChange(rgbToHex(next.r, next.g, next.b));
   };
 
   const handleHslChange = (channel: "h" | "s" | "l", value: string) => {
     const max = channel === "h" ? 360 : 100;
     const num = Math.max(0, Math.min(max, parseInt(value) || 0));
-    const newRgb = hslToRgb(
-      channel === "h" ? num : hsl.h,
-      channel === "s" ? num : hsl.s,
-      channel === "l" ? num : hsl.l,
-    );
+    const next = { ...hsl, [channel]: num };
+    const newRgb = hslToRgb(next.h, next.s, next.l);
     onColorChange(rgbToHex(newRgb.r, newRgb.g, newRgb.b));
+  };
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(formatColor(color, format, alpha));
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1500);
+    } catch {
+      onError?.("copyError");
+    }
   };
 
   const inputBase =
@@ -87,7 +93,6 @@ export const ColorCard: FC<IProps> = ({
             {color}
           </span>
         </div>
-        {/* Ícone de lápis no canto */}
         <div className="absolute -bottom-1 -right-1 bg-white/20 backdrop-blur-sm rounded-full p-1 pointer-events-none">
           <svg xmlns="http://www.w3.org/2000/svg" className="w-3 h-3 text-white" viewBox="0 0 20 20" fill="currentColor">
             <path d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z" />
@@ -105,7 +110,7 @@ export const ColorCard: FC<IProps> = ({
 
       {/* Seletor de formato */}
       <div className="flex border border-white/20 rounded overflow-hidden text-[11px]">
-        {(["hex", "rgb", "hsl"] as ColorFormat[]).map((f) => (
+        {(["hex", "rgb", "rgba", "hsl"] as ColorFormat[]).map((f) => (
           <button
             key={f}
             type="button"
@@ -137,21 +142,42 @@ export const ColorCard: FC<IProps> = ({
         />
       )}
 
-      {format === "rgb" && (
-        <div className="flex gap-1">
-          {(["r", "g", "b"] as const).map((ch) => (
-            <div key={ch} className="flex flex-col items-center gap-0.5">
-              <input
-                type="number"
-                min={0}
-                max={255}
-                value={rgb[ch]}
-                onChange={(e) => handleRgbChange(ch, e.target.value)}
-                className={`${inputBase} w-10 px-0.5 py-1 text-[11px]`}
-              />
-              <span className="text-white/50 text-[10px] uppercase">{ch}</span>
+      {(format === "rgb" || format === "rgba") && (
+        <div className="flex flex-col items-center gap-1.5">
+          <div className="flex gap-1">
+            {(["r", "g", "b"] as const).map((ch) => (
+              <div key={ch} className="flex flex-col items-center gap-0.5">
+                <input
+                  type="number"
+                  min={0}
+                  max={255}
+                  value={rgb[ch]}
+                  onChange={(e) => handleRgbChange(ch, e.target.value)}
+                  className={`${inputBase} w-10 px-0.5 py-1 text-[11px]`}
+                />
+                <span className="text-white/50 text-[10px] uppercase">{ch}</span>
+              </div>
+            ))}
+          </div>
+          {format === "rgba" && (
+            <div className="flex flex-col items-center gap-0.5 w-full">
+              <div className="flex items-center gap-2 justify-center">
+                <input
+                  type="range"
+                  min={0}
+                  max={1}
+                  step={0.01}
+                  value={alpha}
+                  onChange={(e) => setAlpha(parseFloat(e.target.value))}
+                  className="w-20 accent-white/80"
+                />
+                <span className="text-white font-mono text-[11px] w-8 text-center">
+                  {alpha.toFixed(2)}
+                </span>
+              </div>
+              <span className="text-white/50 text-[10px]">{t("alpha")}</span>
             </div>
-          ))}
+          )}
         </div>
       )}
 
@@ -175,14 +201,18 @@ export const ColorCard: FC<IProps> = ({
         </div>
       )}
 
+      {/* Preview do valor que será copiado */}
+      <div className="text-white/40 text-[10px] font-mono truncate max-w-[9rem] text-center">
+        {formatColor(color, format, alpha)}
+      </div>
+
       {/* Botão copiar */}
       <button
         type="button"
-        onClick={onCopy}
+        onClick={handleCopy}
         className={`rounded-md border border-white/30 text-white hover:bg-white/10 transition-colors ${
           compact ? "px-2 py-1 text-xs" : "px-3 py-1 text-sm"
         }`}
-        aria-label={copyAriaLabel}
       >
         {copied ? t("copied") : t("copy")}
       </button>

--- a/src/components/ColorHistory/ColorHistory.tsx
+++ b/src/components/ColorHistory/ColorHistory.tsx
@@ -1,0 +1,54 @@
+import type { FC } from "react";
+import { useTranslation } from "react-i18next";
+
+interface IProps {
+  history: string[];
+  onUseColor: (color: string) => void;
+  onClear: () => void;
+  compact?: boolean;
+}
+
+export const ColorHistory: FC<IProps> = ({
+  history,
+  onUseColor,
+  onClear,
+  compact = false,
+}) => {
+  const { t } = useTranslation();
+
+  if (history.length === 0) return null;
+
+  return (
+    <section className={`border-t border-white/10 ${compact ? "pt-2" : "pt-3 md:pt-4"}`}>
+      <div className="flex items-center justify-between mb-2 px-1">
+        <h3 className="text-white/70 text-xs font-semibold uppercase tracking-wide">
+          {t("colorHistory")}
+        </h3>
+        <button
+          type="button"
+          onClick={onClear}
+          className="text-white/40 hover:text-white/80 text-xs transition-colors"
+          aria-label={t("clearHistory")}
+        >
+          {t("clearHistory")}
+        </button>
+      </div>
+
+      <div className="flex flex-wrap gap-2 justify-center px-1">
+        {history.map((color, i) => (
+          <button
+            key={`${color}-${i}`}
+            type="button"
+            onClick={() => onUseColor(color)}
+            className={`rounded-md border-2 border-white/20 hover:border-white/70 transition-all hover:scale-110 focus:outline-none focus:border-white/60 ${
+              compact ? "w-8 h-8" : "w-10 h-10"
+            }`}
+            style={{ backgroundColor: color }}
+            title={color}
+            aria-label={`${t("useColor")}: ${color}`}
+          />
+        ))}
+      </div>
+    </section>
+  );
+};

--- a/src/components/ExportPalette/ExportPalette.tsx
+++ b/src/components/ExportPalette/ExportPalette.tsx
@@ -1,0 +1,119 @@
+import { type FC, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { type ExportFormat, generateExport } from "../../utils/colorUtils";
+
+interface IProps {
+  colors: string[];
+}
+
+export const ExportPalette: FC<IProps> = ({ colors }) => {
+  const { t } = useTranslation();
+  const [isOpen, setIsOpen] = useState(false);
+  const [format, setFormat] = useState<ExportFormat>("css");
+  const [copied, setCopied] = useState(false);
+
+  if (colors.length === 0) return null;
+
+  const exported = generateExport(colors, format);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(exported);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // silently fail
+    }
+  };
+
+  const formatLabels: Record<ExportFormat, string> = {
+    css: t("cssVars"),
+    scss: "SCSS",
+    json: "JSON",
+    tailwind: "Tailwind",
+  };
+
+  return (
+    <>
+      <div className="text-center pt-1">
+        <button
+          type="button"
+          onClick={() => setIsOpen(true)}
+          className="text-sm text-white/60 hover:text-white border border-white/20 hover:border-white/40 rounded-md px-3 py-1.5 transition-colors"
+        >
+          {t("exportPalette")}
+        </button>
+      </div>
+
+      {isOpen && (
+        <div className="fixed inset-0 z-50 flex items-end md:items-center justify-center p-2">
+          {/* Overlay */}
+          <div
+            className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+            onClick={() => setIsOpen(false)}
+          />
+
+          {/* Modal */}
+          <div className="relative w-full max-w-md bg-black/85 backdrop-blur-md border border-white/20 rounded-2xl p-5 space-y-4">
+            {/* Header */}
+            <div className="flex justify-between items-center">
+              <h3 className="text-white font-semibold">{t("exportPalette")}</h3>
+              <button
+                type="button"
+                onClick={() => setIsOpen(false)}
+                className="text-white/50 hover:text-white transition-colors text-lg leading-none"
+                aria-label={t("close")}
+              >
+                ✕
+              </button>
+            </div>
+
+            {/* Miniaturas das cores */}
+            <div className="flex flex-wrap gap-2">
+              {colors.map((c, i) => (
+                <div
+                  key={i}
+                  className="w-8 h-8 rounded border border-white/20 flex-shrink-0"
+                  style={{ backgroundColor: c }}
+                  title={c}
+                />
+              ))}
+            </div>
+
+            {/* Seletor de formato */}
+            <div className="flex gap-1">
+              {(["css", "scss", "json", "tailwind"] as ExportFormat[]).map((f) => (
+                <button
+                  key={f}
+                  type="button"
+                  onClick={() => setFormat(f)}
+                  className={`flex-1 py-1.5 text-xs rounded border transition-colors ${
+                    format === f
+                      ? "bg-white/20 border-white/40 text-white font-semibold"
+                      : "border-white/10 text-white/50 hover:text-white hover:bg-white/10"
+                  }`}
+                >
+                  {formatLabels[f]}
+                </button>
+              ))}
+            </div>
+
+            {/* Preview */}
+            <pre className="bg-white/5 border border-white/10 rounded-lg p-3 text-xs text-white/80 font-mono overflow-x-auto max-h-44 overflow-y-auto whitespace-pre-wrap break-all">
+              {exported}
+            </pre>
+
+            {/* Botão copiar */}
+            <button
+              type="button"
+              onClick={handleCopy}
+              className="w-full py-2 rounded-lg border border-white/30 text-white hover:bg-white/10 transition-colors text-sm font-medium"
+            >
+              {copied ? t("exportCopied") : t("copyExport")}
+            </button>
+          </div>
+        </div>
+      )}
+    </>
+  );
+};

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -32,5 +32,14 @@
   "settings": "Settings",
   "closeMenu": "Close menu",
   "language": "Language:",
-  "editColor": "Edit color"
+  "editColor": "Edit color",
+  "alpha": "Alpha",
+  "colorHistory": "History",
+  "clearHistory": "Clear history",
+  "useColor": "Use this color",
+  "exportPalette": "Export Palette",
+  "cssVars": "CSS Vars",
+  "copyExport": "Copy",
+  "exportCopied": "Copied!",
+  "close": "Close"
 }

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -32,5 +32,14 @@
   "settings": "設定",
   "closeMenu": "メニューを閉じる",
   "language": "言語:",
-  "editColor": "色を編集"
+  "editColor": "色を編集",
+  "alpha": "不透明度",
+  "colorHistory": "履歴",
+  "clearHistory": "履歴を消去",
+  "useColor": "この色を使用",
+  "exportPalette": "パレットをエクスポート",
+  "cssVars": "CSS変数",
+  "copyExport": "コピー",
+  "exportCopied": "コピーしました!",
+  "close": "閉じる"
 }

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -32,5 +32,14 @@
   "settings": "Configurações",
   "closeMenu": "Fechar menu",
   "language": "Idioma:",
-  "editColor": "Editar cor"
+  "editColor": "Editar cor",
+  "alpha": "Alfa",
+  "colorHistory": "Histórico",
+  "clearHistory": "Limpar histórico",
+  "useColor": "Usar esta cor",
+  "exportPalette": "Exportar Paleta",
+  "cssVars": "CSS Vars",
+  "copyExport": "Copiar",
+  "exportCopied": "Copiado!",
+  "close": "Fechar"
 }

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -32,5 +32,14 @@
   "settings": "Настройки",
   "closeMenu": "Закрыть меню",
   "language": "Язык:",
-  "editColor": "Редактировать цвет"
+  "editColor": "Редактировать цвет",
+  "alpha": "Прозрачность",
+  "colorHistory": "История",
+  "clearHistory": "Очистить историю",
+  "useColor": "Использовать цвет",
+  "exportPalette": "Экспорт палитры",
+  "cssVars": "CSS Vars",
+  "copyExport": "Копировать",
+  "exportCopied": "Скопировано!",
+  "close": "Закрыть"
 }

--- a/src/utils/colorUtils.ts
+++ b/src/utils/colorUtils.ts
@@ -1,5 +1,7 @@
 export interface RGB { r: number; g: number; b: number }
 export interface HSL { h: number; s: number; l: number }
+export type ColorFormat = "hex" | "rgb" | "rgba" | "hsl";
+export type ExportFormat = "css" | "scss" | "json" | "tailwind";
 
 export function hexToRgb(hex: string): RGB | null {
   const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
@@ -79,4 +81,32 @@ export function hslToRgb(h: number, s: number, l: number): RGB {
 
 export function isValidHex(hex: string): boolean {
   return /^#[0-9a-fA-F]{6}$/.test(hex);
+}
+
+export function formatColor(hex: string, format: ColorFormat, alpha = 1): string {
+  const rgb = hexToRgb(hex) ?? { r: 0, g: 0, b: 0 };
+  const a = parseFloat(Math.max(0, Math.min(1, alpha)).toFixed(2));
+  switch (format) {
+    case "hex":  return hex;
+    case "rgb":  return `rgb(${rgb.r}, ${rgb.g}, ${rgb.b})`;
+    case "rgba": return `rgba(${rgb.r}, ${rgb.g}, ${rgb.b}, ${a})`;
+    case "hsl": {
+      const hsl = rgbToHsl(rgb.r, rgb.g, rgb.b);
+      return `hsl(${hsl.h}, ${hsl.s}%, ${hsl.l}%)`;
+    }
+  }
+}
+
+export function generateExport(colors: string[], format: ExportFormat): string {
+  if (colors.length === 0) return "";
+  switch (format) {
+    case "css":
+      return `:root {\n${colors.map((c, i) => `  --color-${i + 1}: ${c};`).join("\n")}\n}`;
+    case "scss":
+      return colors.map((c, i) => `$color-${i + 1}: ${c};`).join("\n");
+    case "json":
+      return JSON.stringify(colors, null, 2);
+    case "tailwind":
+      return `// tailwind.config.js\nmodule.exports = {\n  theme: {\n    extend: {\n      colors: {\n${colors.map((c, i) => `        "color-${i + 1}": "${c}",`).join("\n")}\n      },\n    },\n  },\n};`;
+  }
 }


### PR DESCRIPTION
## Resumo

- Historico de cores: armazena ate 10 cores, clique para reutilizar
- Formatos de copia: HEX, RGB, RGBA com slider de alpha e HSL
- Export de paleta: CSS Vars, SCSS, JSON ou Tailwind config