### PR TITLE
ci: automate version sync and Chrome extension publishing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,10 @@ jobs:
           cache: npm
 
       - name: Instalar dependências
-        run: npm install
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
 
       - name: Build do projeto
         run: npm run build

--- a/.github/workflows/extension-publish.yml
+++ b/.github/workflows/extension-publish.yml
@@ -1,9 +1,7 @@
 name: Build and Publish Chrome Extension
 
 on:
-  push:
-    tags:
-      - "v*.*.*"
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -36,11 +34,6 @@ jobs:
           cd dist-extension
           zip -r ../extension.zip .
           cd ..
-
-      - name: Upload extension to GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          files: extension.zip
 
       - name: Publish to Chrome Web Store
         if: ${{ env.CHROME_EXTENSION_ID != '' }}

--- a/.github/workflows/extension-publish.yml
+++ b/.github/workflows/extension-publish.yml
@@ -1,0 +1,63 @@
+name: Build and Publish Chrome Extension
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Build extension
+        run: npm run build:extension
+
+      - name: Zip extension
+        run: |
+          cd dist-extension
+          zip -r ../extension.zip .
+          cd ..
+
+      - name: Upload extension to GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: extension.zip
+
+      - name: Publish to Chrome Web Store
+        if: ${{ env.CHROME_EXTENSION_ID != '' }}
+        env:
+          CHROME_EXTENSION_ID: ${{ secrets.CHROME_EXTENSION_ID }}
+          CHROME_CLIENT_ID: ${{ secrets.CHROME_CLIENT_ID }}
+          CHROME_CLIENT_SECRET: ${{ secrets.CHROME_CLIENT_SECRET }}
+          CHROME_REFRESH_TOKEN: ${{ secrets.CHROME_REFRESH_TOKEN }}
+        run: |
+          npx chrome-webstore-upload-cli@3 upload \
+            --source extension.zip \
+            --extension-id "$CHROME_EXTENSION_ID" \
+            --client-id "$CHROME_CLIENT_ID" \
+            --client-secret "$CHROME_CLIENT_SECRET" \
+            --refresh-token "$CHROME_REFRESH_TOKEN"
+          npx chrome-webstore-upload-cli@3 publish \
+            --extension-id "$CHROME_EXTENSION_ID" \
+            --client-id "$CHROME_CLIENT_ID" \
+            --client-secret "$CHROME_CLIENT_SECRET" \
+            --refresh-token "$CHROME_REFRESH_TOKEN"

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,7 +6,7 @@ import tseslint from 'typescript-eslint'
 import { globalIgnores } from 'eslint/config'
 
 export default tseslint.config([
-  globalIgnores(['dist']),
+  globalIgnores(['dist', 'dist-extension', 'old']),
   {
     files: ['**/*.{ts,tsx}'],
     extends: [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eye-dropper",
   "private": true,
-  "version": "0.0.0",
+  "version": "1.1.1",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -9,7 +9,8 @@
     "build:extension": "tsc -b && vite build --mode extension",
     "lint": "eslint .",
     "preview": "vite preview",
-    "deploy": "gh-pages -d dist"
+    "deploy": "gh-pages -d dist",
+    "version": "node scripts/sync-version.js && git add public/manifest.json"
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.1.12",

--- a/scripts/sync-version.js
+++ b/scripts/sync-version.js
@@ -1,0 +1,14 @@
+import { readFileSync, writeFileSync } from "fs";
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, "..");
+
+const pkg = JSON.parse(readFileSync(resolve(root, "package.json"), "utf8"));
+const manifestPath = resolve(root, "public/manifest.json");
+const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+
+manifest.version = pkg.version;
+writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + "\n");
+console.log(`manifest.json version synced to ${pkg.version}`);


### PR DESCRIPTION
## Summary

- `scripts/sync-version.js`: sincroniza a versão do `package.json` para o `public/manifest.json` automaticamente via npm lifecycle hook `version`
- `package.json`: versão atualizada de `0.0.0` para `1.1.1` (em sincronia com o manifest), hook `version` adicionado
- `deploy.yml`: substituído `npm install` por `npm ci` e adicionado step de lint
- `extension-publish.yml`: workflow manual (`workflow_dispatch`) para build, zip e publicação da extensão no Chrome Web Store
- `eslint.config.js`: adicionados `dist-extension/` e `old/` ao `globalIgnores`

## Como usar o version bump

```bash
npm version patch   # 1.1.1 → 1.1.2
npm version minor   # 1.1.1 → 1.2.0
npm version major   # 1.1.1 → 2.0.0
```

O hook `version` roda automaticamente: atualiza o `manifest.json` e faz `git add` antes do commit de tag.

## Como publicar a extensão

1. Configure os secrets no repositório: `CHROME_EXTENSION_ID`, `CHROME_CLIENT_ID`, `CHROME_CLIENT_SECRET`, `CHROME_REFRESH_TOKEN`
2. Vá em **Actions → Build and Publish Chrome Extension → Run workflow**

https://claude.ai/code/session_016X1VHXd7jdkPFeAWjA4oS7